### PR TITLE
Fix path typo in deployment script

### DIFF
--- a/scripts/deploy_approval_workflow.py
+++ b/scripts/deploy_approval_workflow.py
@@ -97,12 +97,13 @@ def connect_get(api_id, res_id, arn):
     )
 
 def main():
-    ez = make_zip("approval/sendApprovalEmail.py",      "sendApprovalEmail")
+    # zip the email Lambda source (actual file uses snake_case)
+    ez = make_zip("approval/send_approval_email.py",      "sendApprovalEmail")
     cz = make_zip("approval/handleApprovalCallback.py", "handleApprovalCallback")
 
     email_arn = upsert_lambda(
         "sendApprovalEmail",
-        "sendApprovalEmail.lambda_handler",
+        "send_approval_email.lambda_handler",
         ez
     )
 


### PR DESCRIPTION
## Summary
- fix file path and handler name for `sendApprovalEmail` in deployment script

## Testing
- `python -m py_compile scripts/deploy_approval_workflow.py`


------
https://chatgpt.com/codex/tasks/task_e_6831e62a76708324a603bcb3f2eccead